### PR TITLE
Added code samples for create model armor templates with basic and advance sdp

### DIFF
--- a/modelarmor/composer.json
+++ b/modelarmor/composer.json
@@ -1,0 +1,11 @@
+{
+  "require": {
+      "google/cloud-dlp": "^2.4",
+      "google/cloud-modelarmor": "^0.1.0"
+  },
+  "autoload": {
+   "psr-4": {
+     "Google\\Cloud\\Samples\\ModelArmor\\": "test"
+   }
+}
+}

--- a/modelarmor/composer.json
+++ b/modelarmor/composer.json
@@ -1,11 +1,11 @@
 {
   "require": {
-      "google/cloud-dlp": "^2.4",
-      "google/cloud-modelarmor": "^0.1.0"
+    "google/cloud-dlp": "^2.4",
+    "google/cloud-modelarmor": "^0.1.0"
   },
   "autoload": {
-   "psr-4": {
-     "Google\\Cloud\\Samples\\ModelArmor\\": "test"
-   }
-}
+    "psr-4": {
+      "Google\\Cloud\\Samples\\ModelArmor\\": "test"
+    }
+  }
 }

--- a/modelarmor/phpunit.xml.dist
+++ b/modelarmor/phpunit.xml.dist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  Copyright 2025 Google LLC.
+
+  Licensed under the Apache License, Version 2.0 (the 'License');
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an 'AS IS' BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. 
+-->
+ 
+<phpunit bootstrap="../testing/bootstrap.php">
+  <testsuites>
+    <testsuite name="PHP Secret Manager test">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <log type="coverage-clover" target="build/logs/clover.xml"/>
+  </logging>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./src</directory>
+      <exclude>
+        <directory>./vendor</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+  <php>
+    <env name="PHPUNIT_TESTS" value="1"/>
+  </php>
+</phpunit>

--- a/modelarmor/src/create_template_with_advanced_sdp.php
+++ b/modelarmor/src/create_template_with_advanced_sdp.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) < 4 || count($argv) > 6) {
+    return printf("Usage: php %s PROJECT_ID LOCATION_ID TEMPLATE_ID [INSPECT_TEMPLATE] [DEIDENTIFY_TEMPLATE]\n", basename(__FILE__));
+}
+list($_, $projectId, $locationId, $templateId) = $argv;
+$inspectTemplate = $argv[4] ?? '';
+$deidentifyTemplate = $argv[5] ?? '';
+
+// [START modelarmor_create_template_with_advanced_sdp]
+// Import the ModelArmor client library.
+use Google\Cloud\ModelArmor\V1\Client\ModelArmorClient;
+use Google\Cloud\ModelArmor\V1\SdpAdvancedConfig;
+use Google\Cloud\ModelArmor\V1\Template;
+use Google\Cloud\ModelArmor\V1\FilterConfig;
+use Google\Cloud\ModelArmor\V1\RaiFilterSettings;
+use Google\Cloud\ModelArmor\V1\RaiFilterSettings\RaiFilter;
+use Google\Cloud\ModelArmor\V1\CreateTemplateRequest;
+use Google\Cloud\ModelArmor\V1\RaiFilterType;
+use Google\Cloud\ModelArmor\V1\DetectionConfidenceLevel;
+use Google\Cloud\ModelArmor\V1\SdpFilterSettings;
+
+/** Uncomment and populate these variables in your code */
+// $projectId = "YOUR_GOOGLE_CLOUD_PROJECT"; (e.g. 'my-project');
+// $locationId = 'YOUR_LOCATION_ID'; (e.g. 'my-location');
+// $templateId = 'YOUR_TEMPLATE_ID'; (e.g. 'my-template');
+// $inspectTemplate = 'YOUR_INSPECT_TEMPLATE'; (e.g. 'organizations/{organization}/inspectTemplates/{inspect_template}')
+// $deidentifyTemplate = 'YOUR_DEIDENTIFY_TEMPLATE'; (e.g. 'organizations/{organization}/deidentifyTemplates/{deidentify_template}')
+
+// Specify regional endpoint.
+$options = ['apiEndpoint' => "modelarmor.$locationId.rep.googleapis.com"];
+
+$client = new ModelArmorClient($options);
+
+// Build the resource name of the parent location.
+$parent = $client->locationName($projectId, $locationId);
+
+$filters = [
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::DANGEROUS)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::HARASSMENT)
+        ->setConfidenceLevel(DetectionConfidenceLevel::MEDIUM_AND_ABOVE),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::HATE_SPEECH)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::SEXUALLY_EXPLICIT)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH)
+];
+
+$raiFilterSetting = (new RaiFilterSettings())->setRaiFilters($filters);
+
+$sdpAdvancedConfig = (new SdpAdvancedConfig())
+    ->setInspectTemplate($inspectTemplate)
+    ->setDeidentifyTemplate($deidentifyTemplate);
+
+$sdpSettings = (new SdpFilterSettings())->setAdvancedConfig($sdpAdvancedConfig);
+
+// Define the template configuration with advanced SDP settings.
+$templateFilterConfig = (new FilterConfig())
+    ->setRaiSettings($raiFilterSetting)
+    ->setSdpSettings($sdpSettings);
+
+$template = (new Template())->setFilterConfig($templateFilterConfig);
+
+$request = (new CreateTemplateRequest())
+    ->setParent($parent)
+    ->setTemplateId($templateId)
+    ->setTemplate($template);
+
+$response = $client->createTemplate($request);
+
+printf('Template created: %s' . PHP_EOL, $response->getName());
+// [END modelarmor_create_template_with_advanced_sdp]

--- a/modelarmor/src/create_template_with_basic_sdp.php
+++ b/modelarmor/src/create_template_with_basic_sdp.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+if (count($argv) != 4) {
+    return printf("Usage: php %s PROJECT_ID LOCATION_ID TEMPLATE_ID\n", basename(__FILE__));
+}
+list($_, $projectId, $locationId, $templateId) = $argv;
+
+// [START modelarmor_create_template_with_basic_sdp]
+// Import the ModelArmor client library.
+use Google\Cloud\ModelArmor\V1\Client\ModelArmorClient;
+use Google\Cloud\ModelArmor\V1\RaiFilterType;
+use Google\Cloud\ModelArmor\V1\DetectionConfidenceLevel;
+use Google\Cloud\ModelArmor\V1\SdpBasicConfig\SdpBasicConfigEnforcement;
+use Google\Cloud\ModelArmor\V1\SdpBasicConfig;
+use Google\Cloud\ModelArmor\V1\SdpFilterSettings;
+use Google\Cloud\ModelArmor\V1\FilterConfig;
+use Google\Cloud\ModelArmor\V1\RaiFilterSettings;
+use Google\Cloud\ModelArmor\V1\CreateTemplateRequest;
+use Google\Cloud\ModelArmor\V1\RaiFilterSettings\RaiFilter;
+use Google\Cloud\ModelArmor\V1\Template;
+
+/** Uncomment and populate these variables in your code */
+// $projectId = "YOUR_GOOGLE_CLOUD_PROJECT"; (e.g. 'my-project');
+// $locationId = 'YOUR_LOCATION_ID'; (e.g. 'my-location');
+// $templateId = 'YOUR_TEMPLATE_ID'; (e.g. 'my-template');
+
+// Specify regional endpoint.
+$options = ['apiEndpoint' => "modelarmor.$locationId.rep.googleapis.com"];
+
+// Instantiates a client.
+$client = new ModelArmorClient($options);
+
+// Build the resource name of the parent location.
+$parent = $client->locationName($projectId, $locationId);
+
+$raiFilters = [
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::DANGEROUS)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::HARASSMENT)
+        ->setConfidenceLevel(DetectionConfidenceLevel::MEDIUM_AND_ABOVE),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::HATE_SPEECH)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH),
+    (new RaiFilter())
+        ->setFilterType(RaiFilterType::SEXUALLY_EXPLICIT)
+        ->setConfidenceLevel(DetectionConfidenceLevel::HIGH)
+];
+
+$raiFilterSetting = (new RaiFilterSettings())->setRaiFilters($raiFilters);
+
+$sdpBasicConfig = (new SdpBasicConfig())->setFilterEnforcement(SdpBasicConfigEnforcement::ENABLED);
+
+$sdpSettings = (new SdpFilterSettings())->setBasicConfig($sdpBasicConfig);
+
+// Define the template configuration with basic SDP settings.
+$templateFilterConfig = (new FilterConfig())
+    ->setRaiSettings($raiFilterSetting)
+    ->setSdpSettings($sdpSettings);
+
+$template = (new Template())->setFilterConfig($templateFilterConfig);
+
+$request = (new CreateTemplateRequest())
+    ->setParent($parent)
+    ->setTemplateId($templateId)
+    ->setTemplate($template);
+
+$response = $client->createTemplate($request);
+
+printf('Template created: %s' . PHP_EOL, $response->getName());
+// [END modelarmor_create_template_with_basic_sdp]

--- a/modelarmor/test/BaseTestCase.php
+++ b/modelarmor/test/BaseTestCase.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\ModelArmor\V1\Client\ModelArmorClient;
+use Google\Cloud\ModelArmor\V1\DeleteTemplateRequest;
+use Google\Cloud\TestUtils\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTestCase extends TestCase
+{
+    use TestTrait;
+
+    protected static $client;
+    protected static $templateId;
+    protected static $locationId = 'us-central1';
+
+    public static function setUpBeforeClass(): void
+    {
+        $options = ['apiEndpoint' => 'modelarmor.' . self::$locationId . '.rep.googleapis.com'];
+        self::$client = new ModelArmorClient($options);
+        self::$templateId = static::getTemplatePrefix() . uniqid();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $templateName = self::$client->templateName(self::$projectId, self::$locationId, self::$templateId);
+        try {
+            static::customTeardown();
+            $request = (new DeleteTemplateRequest())->setName($templateName);
+            self::$client->deleteTemplate($request);
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+        self::$client->close();
+    }
+
+    abstract protected static function getTemplatePrefix(): string;
+    protected static function customTeardown(): void
+    {
+    }
+
+    protected function runSnippetfile(string $snippetName, array $params = []): string
+    {
+        $output = $this->runSnippet($snippetName, $params);
+        return $output;
+    }
+
+    protected static function getProjectId()
+    {
+        return self::$projectId;
+    }
+}

--- a/modelarmor/test/createTemplateWithAdvancedSdpTest.php
+++ b/modelarmor/test/createTemplateWithAdvancedSdpTest.php
@@ -43,7 +43,7 @@ class createTemplateWithAdvancedSdpTest extends BaseTestCase
 
     protected static function getTemplatePrefix(): string
     {
-        return 'php-create-template-with-advanced-sdp-';
+        return 'php-template-advanced-sdp-';
     }
 
     protected static function customTeardown(): void

--- a/modelarmor/test/createTemplateWithAdvancedSdpTest.php
+++ b/modelarmor/test/createTemplateWithAdvancedSdpTest.php
@@ -1,0 +1,177 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+use Google\ApiCore\ApiException as GaxApiException;
+use Google\Cloud\Dlp\V2\DeidentifyConfig;
+use Google\Cloud\Dlp\V2\DeleteDeidentifyTemplateRequest;
+use Google\Cloud\Dlp\V2\InfoTypeTransformations;
+use Google\Cloud\Dlp\V2\InfoTypeTransformations\InfoTypeTransformation;
+use Google\Cloud\Dlp\V2\Value;
+use Google\Cloud\Dlp\V2\ReplaceValueConfig;
+use Google\Cloud\Dlp\V2\InspectConfig;
+use Google\Cloud\Dlp\V2\DeleteInspectTemplateRequest;
+use Google\Cloud\Dlp\V2\CreateInspectTemplateRequest;
+use Google\Cloud\Dlp\V2\PrimitiveTransformation;
+use Google\Cloud\Dlp\V2\DeidentifyTemplate;
+use Google\Cloud\Dlp\V2\CreateDeidentifyTemplateRequest;
+use Google\Cloud\Dlp\V2\InspectTemplate;
+use Google\Cloud\Dlp\V2\Client\DlpServiceClient;
+use Google\Cloud\Dlp\V2\InfoType;
+
+class createTemplateWithAdvancedSdpTest extends BaseTestCase
+{
+    private static $inspectTemplateName = '';
+    private static $deidentifyTemplateName = '';
+
+    protected static function getTemplatePrefix(): string
+    {
+        return 'php-create-template-with-advanced-sdp-';
+    }
+
+    protected static function customTeardown(): void
+    {
+        self::delete_dlp_templates(self::$inspectTemplateName, self::$deidentifyTemplateName, self::$locationId);
+    }
+
+    public function testCreateTemplateWithAdvancedSdp()
+    {
+        $projectId = self::getProjectId();
+        $templates = self::create_dlp_templates($projectId, self::$locationId);
+        self::$inspectTemplateName = $templates['inspectTemplateName'];
+        self::$deidentifyTemplateName = $templates['deidentifyTemplateName'];
+        $output = $this->runSnippetfile('create_template_with_advanced_sdp', [
+            $projectId,
+            self::$locationId,
+            self::$templateId,
+            self::$inspectTemplateName,
+            self::$deidentifyTemplateName,
+        ]);
+
+        $expectedTemplateString = 'Template created: projects/' . $projectId . '/locations/' . self::$locationId . '/templates/' . self::$templateId;
+        $this->assertStringContainsString($expectedTemplateString, $output);
+    }
+
+    // Helper functions
+
+    /**
+     * Creates DLP templates for inspect and deidentify configurations.
+     *
+     * @param string $projectId  Google Cloud Project ID
+     * @param string $locationId Location ID
+     *
+     * @return array
+     * @throws GaxApiException
+     */
+    public static function create_dlp_templates(string $projectId, string $locationId): array
+    {
+        // Specify regional endpoint.
+        $options = ['apiEndpoint' => "dlp.$locationId.rep.googleapis.com"];
+
+        // Instantiate a client.
+        $dlpClient = new DlpServiceClient($options);
+
+        // Generate unique template IDs.
+        $inspectTemplateId = 'model-armor-inspect-template-' . uniqid();
+        $deidentifyTemplateId = 'model-armor-deidentify-template-' . uniqid();
+        $parent = $dlpClient->locationName($projectId, $locationId);
+
+        try {
+            $inspectConfig = (new InspectConfig())
+                ->setInfoTypes([
+                    (new InfoType())->setName('EMAIL_ADDRESS'),
+                    (new InfoType())->setName('PHONE_NUMBER'),
+                    (new InfoType())->setName('US_INDIVIDUAL_TAXPAYER_IDENTIFICATION_NUMBER'),
+                ]);
+            $inspectTemplate = (new InspectTemplate())
+                ->setInspectConfig($inspectConfig);
+            $inspectTemplateRequest = (new CreateInspectTemplateRequest())
+                ->setParent($parent)
+                ->setTemplateId($inspectTemplateId)
+                ->setInspectTemplate($inspectTemplate);
+
+            // Create inspect template.
+            $inspectTemplateResponse = $dlpClient->createInspectTemplate($inspectTemplateRequest);
+            $inspectTemplateName = $inspectTemplateResponse->getName();
+
+            $replaceValueConfig = (new ReplaceValueConfig())->setNewValue((new Value())->setStringValue('[REDACTED]'));
+            $primitiveTrasformation = (new PrimitiveTransformation())->setReplaceConfig($replaceValueConfig);
+            $transformations = (new InfoTypeTransformation())
+                ->setInfoTypes([])
+                ->setPrimitiveTransformation($primitiveTrasformation);
+
+            $infoTypeTransformations = (new InfoTypeTransformations())
+                ->setTransformations([$transformations]);
+            $deidentifyconfig = (new DeidentifyConfig())->setInfoTypeTransformations($infoTypeTransformations);
+            $deidentifyTemplate = (new DeidentifyTemplate())->setDeidentifyConfig($deidentifyconfig);
+            $deidentifyTemplateRequest = (new CreateDeidentifyTemplateRequest())
+                ->setParent($parent)
+                ->setTemplateId($deidentifyTemplateId)
+                ->setDeidentifyTemplate($deidentifyTemplate);
+
+            // Create deidentify template.
+            $deidentifyTemplateResponse = $dlpClient->createDeidentifyTemplate($deidentifyTemplateRequest);
+            $deidentifyTemplateName = $deidentifyTemplateResponse->getName();
+
+            // Return template names.
+            return [
+                'inspectTemplateName' => $inspectTemplateName,
+                'deidentifyTemplateName' => $deidentifyTemplateName,
+            ];
+        } catch (GaxApiException $e) {
+            throw $e;
+        }
+    }
+
+    /**
+     * Deletes DLP templates for inspect and deidentify configurations.
+     *
+     * @param string $inspectTemplateName
+     * @param string $deidentifyTemplateName
+     * @param string $locationId
+     *
+     * @throws GaxApiException
+     */
+    public static function delete_dlp_templates(string $inspectTemplateName, string $deidentifyTemplateName, string $locationId): void
+    {
+        // Instantiate a client.
+        $dlpClient = new DlpServiceClient([
+            'apiEndpoint' => "dlp.{$locationId}.rep.googleapis.com",
+        ]);
+
+        try {
+            // Delete inspect template.
+            if ($inspectTemplateName) {
+                $dlpDltInspectRequest = (new DeleteInspectTemplateRequest())->setName($inspectTemplateName);
+                $dlpClient->deleteInspectTemplate($dlpDltInspectRequest);
+            }
+
+            // Delete deidentify template.
+            if ($deidentifyTemplateName) {
+                $dlpDltDeIndetifyRequest = (new DeleteDeidentifyTemplateRequest())->setName($deidentifyTemplateName);
+                $dlpClient->deleteDeidentifyTemplate($dlpDltDeIndetifyRequest);
+            }
+        } catch (GaxApiException $e) {
+            if ($e->getStatus() != 'NOT_FOUND') {
+                throw $e;
+            }
+        }
+    }
+}

--- a/modelarmor/test/createTemplateWithBasicSdpTest.php
+++ b/modelarmor/test/createTemplateWithBasicSdpTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Copyright 2025 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+declare(strict_types=1);
+
+namespace Google\Cloud\Samples\ModelArmor;
+
+class createTemplateWithBasicSdpTest extends BaseTestCase
+{
+    protected static function getTemplatePrefix(): string
+    {
+        return 'php-create-template-with-basic-sdp-';
+    }
+
+    public function testCreateTemplateWithBasicSdp()
+    {
+        $projectId = self::getProjectId();
+        $output = $this->runSnippetfile('create_template_with_basic_sdp', [
+            $projectId,
+            self::$locationId,
+            self::$templateId,
+        ]);
+
+        $expectedTemplateString = 'Template created: projects/' . $projectId . '/locations/' . self::$locationId . '/templates/' . self::$templateId;
+        $this->assertStringContainsString($expectedTemplateString, $output);
+    }
+}

--- a/modelarmor/test/createTemplateWithBasicSdpTest.php
+++ b/modelarmor/test/createTemplateWithBasicSdpTest.php
@@ -23,7 +23,7 @@ class createTemplateWithBasicSdpTest extends BaseTestCase
 {
     protected static function getTemplatePrefix(): string
     {
-        return 'php-create-template-with-basic-sdp-';
+        return 'php-template-basic-sdp-';
     }
 
     public function testCreateTemplateWithBasicSdp()


### PR DESCRIPTION
This PR included following code snippets for PHP
- create_template_with_basic_sdp.php
- create_template_with_advanced_sdp.php

Along with their test cases in following files respectively
- createTemplateWithBasicSdpTest.php
- createTemplateWithAdvancedSdpTest.php